### PR TITLE
vm.sh: put mnt/ onto the iso image

### DIFF
--- a/user-data
+++ b/user-data
@@ -8,7 +8,7 @@ sudo: 'ALL=(ALL) NOPASSWD:ALL'
 ssh_authorized_keys:
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQR4bv/n0rVI0ZHV4QoEjNrnHsUFFAcLJ6FWnnJyI31aFXWjjPf3NkbynPqqv3ksk9mj6jJzIBnlo2lZ0kLKIlnblJAyz0GVctxPsBQjzijgLPWTWXS/cLoyLZNS7AsqyTe9rzUATDHmBSje5FaJ6Shas2fybiD5V56fVekgen+sKVBWyFAKsxlWV1EytH5WLn0X0H6K50eCA7sNDfNlGs8k8EXmQPmLOEV55nGI4xBxLmAwx/dn9F3t2EhBwGzw1B6Zc4HA/ayWtJcoARO3gNiazTHKZUz37AAoJ2MnLB698L39aYZ/M55zduSLcyUqF+DBHMfzHH3QRsG0kzv+X9
 mounts:
-  - [ /dev/sdb1, /mnt, auto, "defaults" ]
+  - [ /dev/cdrom, /mnt, auto, "defaults" ]
 yum_repos:
     RHEL-8-NIGHTLY-BaseOS:
         name: baseos

--- a/vm.sh
+++ b/vm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 CLOUD_IMAGE=$1
 
 if [ -z "$CLOUD_IMAGE" ]; then
@@ -15,12 +17,11 @@ genisoimage \
 	-volid cidata \
 	-joliet \
 	-rock \
-	user-data meta-data
+	user-data meta-data mnt/.
 
 qemu-kvm \
 	-m 1024 -snapshot \
 	-cdrom cloudinit.iso \
 	-net nic,model=virtio \
 	-net user,hostfwd=tcp::2222-:22,hostfwd=tcp::9091-:9090 \
-	-drive file=fat:mnt/,index=1 \
 	$CLOUD_IMAGE


### PR DESCRIPTION
The fat driver is awkward to use, because it breaks if the underlying
directory changes.